### PR TITLE
HDR compatibility, parking brake, min FG version, prop textures

### DIFF
--- a/Config/dhc6-controls.xml
+++ b/Config/dhc6-controls.xml
@@ -382,7 +382,7 @@
     </fuel>
 
     <gear>
-        <parkingbrake-lever type="bool">1</parkingbrake-lever>
+        <brake-parking type="bool">1</brake-parking>
         <parkingbrake-lever-pos type="double">1</parkingbrake-lever-pos>
         <tiller type="double">0</tiller>
         <tiller-enabled type="bool">1</tiller-enabled>

--- a/Config/dhc6-input.xml
+++ b/Config/dhc6-input.xml
@@ -365,11 +365,11 @@
             <desc>Parking Brakes</desc>
             <binding>
                 <command>property-toggle</command>
-                <property>/controls/gear/parkingbrake-lever</property>
+                <property>/controls/gear/brake-parking</property>
             </binding>
             <binding>
                 <command>nasal</command>
-                <script>gui.popupTip(sprintf("Parking brake: %i", getprop("/controls/gear/parkingbrake-lever")), 5);</script>
+                <script>gui.popupTip(sprintf("Parking brake: %i", getprop("/controls/gear/brake-parking")), 5);</script>
             </binding>
         </key>
 

--- a/Models/DHC6.xml
+++ b/Models/DHC6.xml
@@ -1530,17 +1530,15 @@
         <object-name>SpinnerRRot</object-name>
     </animation-->
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>Lrdoor.glass</object-name>
         <object-name>glass</object-name>
         <object-name>LHdoor.glass</object-name>
         <object-name>RHdoor.glass</object-name>
         <object-name>RRdoor.glass</object-name>        
         <object-name>landing_light_cover</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>select</type>

--- a/Models/Effects/interior/dhc6-interior-vitre-reflection.eff
+++ b/Models/Effects/interior/dhc6-interior-vitre-reflection.eff
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<PropertyList>
+	<name>dhc6-interior-vitre-reflection</name>
+	<inherits-from>Effects/glass</inherits-from>
+	<parameters>
+		<frost-level>0</frost-level>
+		<fog-level>0</fog-level>
+		<texture n="3">
+			<type>cubemap</type>
+			<images>
+				<positive-x>Aircraft/dhc6/Models/Effects/interior/default_px.png</positive-x>
+				<negative-x>Aircraft/dhc6/Models/Effects/interior/default_nx.png</negative-x>
+				<positive-y>Aircraft/dhc6/Models/Effects/interior/default_py.png</positive-y>
+				<negative-y>Aircraft/dhc6/Models/Effects/interior/default_ny.png</negative-y>
+				<positive-z>Aircraft/dhc6/Models/Effects/interior/default_pz.png</positive-z>
+				<negative-z>Aircraft/dhc6/Models/Effects/interior/default_nz.png</negative-z>
+			</images>
+		</texture>
+		<use-reflection type="int">1</use-reflection>
+		<reflection-strength type="float">1.0</reflection-strength>
+		<surface-mapping-scheme type="int">2</surface-mapping-scheme>
+		<rnorm>0</rnorm>
+        <gsnorm>0</gsnorm>
+	</parameters>
+</PropertyList>

--- a/Models/Flightdeck/Instruments/ai/ai.ac
+++ b/Models/Flightdeck/Instruments/ai/ai.ac
@@ -1,6 +1,6 @@
 AC3Db
 MATERIAL "transparent.000" rgb 1 1 1 amb 1 1 1 emis 0.2 0.2 0.2 spec 0.502 0.502 0.502 shi 64 trans 0
-MATERIAL "DefaultWhite" rgb 0.549 0.569 0.592 amb 0 0 0 emis 0.1 0.1 0.1 spec 1 1 1 shi 50 trans 0.804
+MATERIAL "glass.000" rgb 0.014 0.014 0.014 amb 0.5 0.5 0.5 emis 0 0 0 spec 0.844 0.844 0.844 shi 5 trans 0.850
 MATERIAL "transparent.001" rgb 1 1 1 amb 1 1 1 emis 0.1 0.1 0.1 spec 0.502 0.502 0.502 shi 64 trans 0
 OBJECT world
 kids 10

--- a/Models/Flightdeck/Instruments/ai/ai0.xml
+++ b/Models/Flightdeck/Instruments/ai/ai0.xml
@@ -16,7 +16,7 @@
     </animation>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/ai/ai0.xml
+++ b/Models/Flightdeck/Instruments/ai/ai0.xml
@@ -15,12 +15,10 @@
         <object-name>vitre</object-name>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/ai/ai1.xml
+++ b/Models/Flightdeck/Instruments/ai/ai1.xml
@@ -16,7 +16,7 @@
     </animation>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/ai/ai1.xml
+++ b/Models/Flightdeck/Instruments/ai/ai1.xml
@@ -15,12 +15,10 @@
         <object-name>vitre</object-name>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/airtemp/airtemp.ac
+++ b/Models/Flightdeck/Instruments/airtemp/airtemp.ac
@@ -1,5 +1,5 @@
 AC3Db
-MATERIAL "airtemp" rgb 0.549 0.569 0.592  amb 0 0 0  emis 0.043 0.043 0.043  spec 1 1 1  shi 50  trans 0.804
+MATERIAL "glass.000" rgb 0.014 0.014 0.014 amb 0.5 0.5 0.5 emis 0 0 0 spec 0.844 0.844 0.844 shi 5 trans 0.850
 MATERIAL "transparent.001" rgb 1 1 1  amb 1 1 1  emis 0.043 0.043 0.043  spec 0.502 0.502 0.502  shi 64  trans 0
 OBJECT world
 kids 5

--- a/Models/Flightdeck/Instruments/airtemp/airtemp.xml
+++ b/Models/Flightdeck/Instruments/airtemp/airtemp.xml
@@ -11,12 +11,10 @@
         <object-name>vitre</object-name>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/airtemp/airtemp.xml
+++ b/Models/Flightdeck/Instruments/airtemp/airtemp.xml
@@ -12,7 +12,7 @@
     </animation>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/alt/alt1-3d0.xml
+++ b/Models/Flightdeck/Instruments/alt/alt1-3d0.xml
@@ -28,12 +28,10 @@
         <object-name>vitre</object-name>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/alt/alt1-3d0.xml
+++ b/Models/Flightdeck/Instruments/alt/alt1-3d0.xml
@@ -29,7 +29,7 @@
     </animation>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/alt/alt1-3d1.xml
+++ b/Models/Flightdeck/Instruments/alt/alt1-3d1.xml
@@ -28,12 +28,10 @@
         <object-name>vitre</object-name>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/alt/alt1-3d1.xml
+++ b/Models/Flightdeck/Instruments/alt/alt1-3d1.xml
@@ -29,7 +29,7 @@
     </animation>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/alt/alt2.ac
+++ b/Models/Flightdeck/Instruments/alt/alt2.ac
@@ -1,5 +1,5 @@
 AC3Db
-MATERIAL "ai" rgb 0.549 0.569 0.592  amb 0 0 0  emis 0.043 0.043 0.043  spec 1 1 1  shi 50  trans 0.804
+MATERIAL "glass.000" rgb 0.014 0.014 0.014 amb 0.5 0.5 0.5 emis 0 0 0 spec 0.844 0.844 0.844 shi 5 trans 0.850
 MATERIAL "transparent" rgb 1 1 1  amb 1 1 1  emis 0.043 0.043 0.043  spec 0.502 0.502 0.502  shi 64  trans 0
 OBJECT world
 kids 11

--- a/Models/Flightdeck/Instruments/asi/asi-gauge.ac
+++ b/Models/Flightdeck/Instruments/asi/asi-gauge.ac
@@ -1,5 +1,5 @@
 AC3Db
-MATERIAL "WhitePaint" rgb 0.549 0.569 0.592  amb 0 0 0  emis 0.043 0.043 0.043  spec 1 1 1  shi 50  trans 0.804
+MATERIAL "glass.000" rgb 0.014 0.014 0.014 amb 0.5 0.5 0.5 emis 0 0 0 spec 0.844 0.844 0.844 shi 5 trans 0.850
 MATERIAL "transparent.001" rgb 1 1 1  amb 1 1 1  emis 0.043 0.043 0.043  spec 0.502 0.502 0.502  shi 64  trans 0
 OBJECT world
 kids 5

--- a/Models/Flightdeck/Instruments/asi/asi0.xml
+++ b/Models/Flightdeck/Instruments/asi/asi0.xml
@@ -11,12 +11,10 @@
         <object-name>vitre</object-name>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/asi/asi0.xml
+++ b/Models/Flightdeck/Instruments/asi/asi0.xml
@@ -12,7 +12,7 @@
     </animation>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/asi/asi1.xml
+++ b/Models/Flightdeck/Instruments/asi/asi1.xml
@@ -11,12 +11,10 @@
         <object-name>vitre</object-name>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/asi/asi1.xml
+++ b/Models/Flightdeck/Instruments/asi/asi1.xml
@@ -12,7 +12,7 @@
     </animation>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/fuel/LHfuelflow.xml
+++ b/Models/Flightdeck/Instruments/fuel/LHfuelflow.xml
@@ -16,7 +16,7 @@ Syd Adams
     </animation>
   
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/fuel/LHfuelflow.xml
+++ b/Models/Flightdeck/Instruments/fuel/LHfuelflow.xml
@@ -15,12 +15,10 @@ Syd Adams
         <object-name>vitre</object-name>
     </animation>
   
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/fuel/RHfuelflow.xml
+++ b/Models/Flightdeck/Instruments/fuel/RHfuelflow.xml
@@ -16,7 +16,7 @@ Syd Adams
     </animation>
   
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/fuel/RHfuelflow.xml
+++ b/Models/Flightdeck/Instruments/fuel/RHfuelflow.xml
@@ -15,12 +15,10 @@ Syd Adams
         <object-name>vitre</object-name>
     </animation>
   
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/fuel/fuel-qty.ac
+++ b/Models/Flightdeck/Instruments/fuel/fuel-qty.ac
@@ -1,5 +1,5 @@
 AC3Db
-MATERIAL "transparent" rgb 0.549 0.569 0.592  amb 0 0 0  emis 0.043 0.043 0.043  spec 1 1 1  shi 50  trans 0.804
+MATERIAL "glass.000" rgb 0.014 0.014 0.014 amb 0.5 0.5 0.5 emis 0 0 0 spec 0.844 0.844 0.844 shi 5 trans 0.850
 MATERIAL "DefaultWhite" rgb 1 1 1  amb 1 1 1  emis 0.043 0.043 0.043  spec 0.502 0.502 0.502  shi 64  trans 0
 OBJECT world
 kids 6

--- a/Models/Flightdeck/Instruments/fuel/fuel-qty0.xml
+++ b/Models/Flightdeck/Instruments/fuel/fuel-qty0.xml
@@ -17,7 +17,7 @@ Syd Adams
     </animation>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/fuel/fuel-qty0.xml
+++ b/Models/Flightdeck/Instruments/fuel/fuel-qty0.xml
@@ -16,12 +16,10 @@ Syd Adams
         <object-name>vitre</object-name>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/fuel/fuel-qty1.xml
+++ b/Models/Flightdeck/Instruments/fuel/fuel-qty1.xml
@@ -17,7 +17,7 @@ Syd Adams
     </animation>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/fuel/fuel-qty1.xml
+++ b/Models/Flightdeck/Instruments/fuel/fuel-qty1.xml
@@ -16,12 +16,10 @@ Syd Adams
         <object-name>vitre</object-name>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/fuel/fuelflow.ac
+++ b/Models/Flightdeck/Instruments/fuel/fuelflow.ac
@@ -1,5 +1,5 @@
 AC3Db
-MATERIAL "transparent" rgb 0.549 0.569 0.592  amb 0 0 0  emis 0.043 0.043 0.043  spec 1 1 1  shi 50  trans 0.804
+MATERIAL "glass.000" rgb 0.014 0.014 0.014 amb 0.5 0.5 0.5 emis 0 0 0 spec 0.844 0.844 0.844 shi 5 trans 0.850
 MATERIAL "WhitePaint" rgb 1 1 1  amb 1 1 1  emis 0.043 0.043 0.043  spec 0.502 0.502 0.502  shi 64  trans 0
 OBJECT world
 kids 5

--- a/Models/Flightdeck/Instruments/hi/hi.ac
+++ b/Models/Flightdeck/Instruments/hi/hi.ac
@@ -1,5 +1,5 @@
 AC3Db
-MATERIAL "transparent.002" rgb 0.549 0.569 0.592  amb 0 0 0  emis 0.043 0.043 0.043  spec 1 1 1  shi 50  trans 0.804
+MATERIAL "glass.000" rgb 0.014 0.014 0.014 amb 0.5 0.5 0.5 emis 0 0 0 spec 0.844 0.844 0.844 shi 5 trans 0.850
 MATERIAL "ai.002" rgb 1 1 1  amb 1 1 1  emis 0.043 0.043 0.043  spec 0.502 0.502 0.502  shi 64  trans 0
 OBJECT world
 kids 13

--- a/Models/Flightdeck/Instruments/hi/hi.xml
+++ b/Models/Flightdeck/Instruments/hi/hi.xml
@@ -29,12 +29,10 @@
         <object-name>vitre</object-name>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/hi/hi.xml
+++ b/Models/Flightdeck/Instruments/hi/hi.xml
@@ -30,7 +30,7 @@
     </animation>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/hyd/hydpress.ac
+++ b/Models/Flightdeck/Instruments/hyd/hydpress.ac
@@ -1,5 +1,5 @@
 AC3Db
-MATERIAL "transparent.001" rgb 0.549 0.569 0.592  amb 0 0 0  emis 0.043 0.043 0.043  spec 1 1 1  shi 50  trans 0.804
+MATERIAL "glass.000" rgb 0.014 0.014 0.014 amb 0.5 0.5 0.5 emis 0 0 0 spec 0.844 0.844 0.844 shi 5 trans 0.850
 MATERIAL "ai.003" rgb 1 1 1  amb 1 1 1  emis 0.043 0.043 0.043  spec 0.502 0.502 0.502  shi 64  trans 0
 OBJECT world
 kids 5

--- a/Models/Flightdeck/Instruments/hyd/hydpress.xml
+++ b/Models/Flightdeck/Instruments/hyd/hydpress.xml
@@ -11,12 +11,10 @@
         <object-name>vitre</object-name>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/hyd/hydpress.xml
+++ b/Models/Flightdeck/Instruments/hyd/hydpress.xml
@@ -12,7 +12,7 @@
     </animation>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/ki206/ki206.ac
+++ b/Models/Flightdeck/Instruments/ki206/ki206.ac
@@ -1,5 +1,5 @@
 AC3Db
-MATERIAL "transparent.003" rgb 0.549 0.569 0.592  amb 0 0 0  emis 0.043 0.043 0.043  spec 1 1 1  shi 50  trans 0.804
+MATERIAL "glass.000" rgb 0.014 0.014 0.014 amb 0.5 0.5 0.5 emis 0 0 0 spec 0.844 0.844 0.844 shi 5 trans 0.850
 MATERIAL "DefaultWhite.005" rgb 1 1 1  amb 1 1 1  emis 0.043 0.043 0.043  spec 0.502 0.502 0.502  shi 64  trans 0
 OBJECT world
 kids 14

--- a/Models/Flightdeck/Instruments/ki206/ki206_1.xml
+++ b/Models/Flightdeck/Instruments/ki206/ki206_1.xml
@@ -56,7 +56,7 @@
     </animation>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/ki206/ki206_1.xml
+++ b/Models/Flightdeck/Instruments/ki206/ki206_1.xml
@@ -55,12 +55,10 @@
         <object-name>vitre</object-name>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/ki206/ki206_2.xml
+++ b/Models/Flightdeck/Instruments/ki206/ki206_2.xml
@@ -56,7 +56,7 @@
     </animation>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/ki206/ki206_2.xml
+++ b/Models/Flightdeck/Instruments/ki206/ki206_2.xml
@@ -55,12 +55,10 @@
         <object-name>vitre</object-name>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/oil/LHoilpsi.xml
+++ b/Models/Flightdeck/Instruments/oil/LHoilpsi.xml
@@ -17,7 +17,7 @@ Syd Adams
     </animation>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/oil/LHoilpsi.xml
+++ b/Models/Flightdeck/Instruments/oil/LHoilpsi.xml
@@ -16,12 +16,10 @@ Syd Adams
         <object-name>vitre</object-name>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/oil/LHoiltemp.xml
+++ b/Models/Flightdeck/Instruments/oil/LHoiltemp.xml
@@ -16,7 +16,7 @@ Syd Adams
     </animation>
   
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/oil/LHoiltemp.xml
+++ b/Models/Flightdeck/Instruments/oil/LHoiltemp.xml
@@ -15,12 +15,10 @@ Syd Adams
         <object-name>vitre</object-name>
     </animation>
   
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/oil/RHoilpsi.xml
+++ b/Models/Flightdeck/Instruments/oil/RHoilpsi.xml
@@ -17,7 +17,7 @@ Syd Adams
     </animation>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/oil/RHoilpsi.xml
+++ b/Models/Flightdeck/Instruments/oil/RHoilpsi.xml
@@ -16,12 +16,10 @@ Syd Adams
         <object-name>vitre</object-name>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/oil/RHoiltemp.xml
+++ b/Models/Flightdeck/Instruments/oil/RHoiltemp.xml
@@ -16,7 +16,7 @@ Syd Adams
     </animation>
   
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/oil/RHoiltemp.xml
+++ b/Models/Flightdeck/Instruments/oil/RHoiltemp.xml
@@ -15,12 +15,10 @@ Syd Adams
         <object-name>vitre</object-name>
     </animation>
   
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/oil/oilpsi.ac
+++ b/Models/Flightdeck/Instruments/oil/oilpsi.ac
@@ -1,5 +1,5 @@
 AC3Db
-MATERIAL "transparent.002" rgb 0.549 0.569 0.592  amb 0 0 0  emis 0.043 0.043 0.043  spec 1 1 1  shi 50  trans 0.804
+MATERIAL "glass.000" rgb 0.014 0.014 0.014 amb 0.5 0.5 0.5 emis 0 0 0 spec 0.844 0.844 0.844 shi 5 trans 0.850
 MATERIAL "WhitePaint" rgb 1 1 1  amb 1 1 1  emis 0.043 0.043 0.043  spec 0.502 0.502 0.502  shi 64  trans 0
 OBJECT world
 kids 6

--- a/Models/Flightdeck/Instruments/oil/oiltemp.ac
+++ b/Models/Flightdeck/Instruments/oil/oiltemp.ac
@@ -1,5 +1,5 @@
 AC3Db
-MATERIAL "transparent.002" rgb 0.549 0.569 0.592  amb 0 0 0  emis 0.043 0.043 0.043  spec 1 1 1  shi 50  trans 0.804
+MATERIAL "glass.000" rgb 0.014 0.014 0.014 amb 0.5 0.5 0.5 emis 0 0 0 spec 0.844 0.844 0.844 shi 5 trans 0.850
 MATERIAL "WhitePaint.001" rgb 1 1 1  amb 1 1 1  emis 0.043 0.043 0.043  spec 0.502 0.502 0.502  shi 64  trans 0
 OBJECT world
 kids 5

--- a/Models/Flightdeck/Instruments/prop/LHrpm.xml
+++ b/Models/Flightdeck/Instruments/prop/LHrpm.xml
@@ -18,7 +18,7 @@ Syd Adams
     </animation>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/prop/LHrpm.xml
+++ b/Models/Flightdeck/Instruments/prop/LHrpm.xml
@@ -17,12 +17,10 @@ Syd Adams
         <object-name>vitre</object-name>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/prop/RHrpm.xml
+++ b/Models/Flightdeck/Instruments/prop/RHrpm.xml
@@ -18,7 +18,7 @@ Syd Adams
     </animation>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/prop/RHrpm.xml
+++ b/Models/Flightdeck/Instruments/prop/RHrpm.xml
@@ -17,12 +17,10 @@ Syd Adams
         <object-name>vitre</object-name>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/prop/prop-rpm.ac
+++ b/Models/Flightdeck/Instruments/prop/prop-rpm.ac
@@ -1,5 +1,5 @@
 AC3Db
-MATERIAL "transparent.002" rgb 0.549 0.569 0.592  amb 0 0 0  emis 0.043 0.043 0.043  spec 1 1 1  shi 50  trans 0.804
+MATERIAL "glass.000" rgb 0.014 0.014 0.014 amb 0.5 0.5 0.5 emis 0 0 0 spec 0.844 0.844 0.844 shi 5 trans 0.850
 MATERIAL "DefaultWhite.001" rgb 1 1 1  amb 1 1 1  emis 0.043 0.043 0.043  spec 0.502 0.502 0.502  shi 64  trans 0
 OBJECT world
 kids 7

--- a/Models/Flightdeck/Instruments/radar-alt/radar-alt.ac
+++ b/Models/Flightdeck/Instruments/radar-alt/radar-alt.ac
@@ -1,5 +1,5 @@
 AC3Db
-MATERIAL "WhitePaint" rgb 0.549 0.569 0.592  amb 0 0 0  emis 0.1 0.1 0.1  spec 1 1 1  shi 50  trans 0.804
+MATERIAL "glass.000" rgb 0.014 0.014 0.014 amb 0.5 0.5 0.5 emis 0 0 0 spec 0.844 0.844 0.844 shi 5 trans 0.850
 MATERIAL "illum" rgb 0.9 0.9 0.9  amb 0.9 0.9 0.9  emis 0.1 0.1 0.1  spec 0.0874 0.0874 0.0874  shi 50  trans 0
 MATERIAL "lights" rgb 1 1 1  amb 1 1 1  emis 0.102 0.102 0.102  spec 0.098 0.098 0.098  shi 50  trans 0
 MATERIAL "interior" rgb 0.8 0.8 0.8  amb 0.8 0.8 0.8  emis 0.1 0.1 0.1  spec 0.32 0.32 0.32  shi 50  trans 0

--- a/Models/Flightdeck/Instruments/radar-alt/radar-alt.xml
+++ b/Models/Flightdeck/Instruments/radar-alt/radar-alt.xml
@@ -17,7 +17,7 @@
     </animation>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/radar-alt/radar-alt.xml
+++ b/Models/Flightdeck/Instruments/radar-alt/radar-alt.xml
@@ -16,12 +16,10 @@
         <object-name>vitre</object-name>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/rmi/rmi-2.xml
+++ b/Models/Flightdeck/Instruments/rmi/rmi-2.xml
@@ -149,7 +149,7 @@
     </effect>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/rmi/rmi-2.xml
+++ b/Models/Flightdeck/Instruments/rmi/rmi-2.xml
@@ -148,12 +148,10 @@
         <object-name>vitre.001</object-name-->
     </effect>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>material</type>

--- a/Models/Flightdeck/Instruments/rmi/rmi.ac
+++ b/Models/Flightdeck/Instruments/rmi/rmi.ac
@@ -1,5 +1,5 @@
 AC3Db
-MATERIAL "transparent.004" rgb 0.549 0.569 0.592  amb 0 0 0  emis 0.043 0.043 0.043  spec 1 1 1  shi 50  trans 0.804
+MATERIAL "glass.000" rgb 0.014 0.014 0.014 amb 0.5 0.5 0.5 emis 0 0 0 spec 0.844 0.844 0.844 shi 5 trans 0.850
 MATERIAL "ai.002" rgb 1 1 1  amb 1 1 1  emis 0.043 0.043 0.043  spec 0.502 0.502 0.502  shi 64  trans 0
 OBJECT world
 kids 19

--- a/Models/Flightdeck/Instruments/rmi/rmi.xml
+++ b/Models/Flightdeck/Instruments/rmi/rmi.xml
@@ -146,12 +146,10 @@
         <object-name>vitre.001</object-name-->
     </effect>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>material</type>

--- a/Models/Flightdeck/Instruments/rmi/rmi.xml
+++ b/Models/Flightdeck/Instruments/rmi/rmi.xml
@@ -147,7 +147,7 @@
     </effect>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/tc/tc.ac
+++ b/Models/Flightdeck/Instruments/tc/tc.ac
@@ -1,5 +1,5 @@
 AC3Db
-MATERIAL "WhitePaint" rgb 0.549 0.569 0.592  amb 0 0 0  emis 0.043 0.043 0.043  spec 1 1 1  shi 50  trans 0.804
+MATERIAL "glass.000" rgb 0.014 0.014 0.014 amb 0.5 0.5 0.5 emis 0 0 0 spec 0.844 0.844 0.844 shi 5 trans 0.850
 MATERIAL "transparent.001" rgb 1 1 1  amb 1 1 1  emis 0.043 0.043 0.043  spec 0.502 0.502 0.502  shi 64  trans 0
 OBJECT world
 kids 7

--- a/Models/Flightdeck/Instruments/tc/tc.xml
+++ b/Models/Flightdeck/Instruments/tc/tc.xml
@@ -23,7 +23,7 @@
     </animation>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/tc/tc.xml
+++ b/Models/Flightdeck/Instruments/tc/tc.xml
@@ -22,12 +22,10 @@
         <object-name>vitre</object-name>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/torque/LHgg.xml
+++ b/Models/Flightdeck/Instruments/torque/LHgg.xml
@@ -18,12 +18,10 @@ Syd Adams
         <object-name>vitre</object-name> 
     </animation>
  
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/torque/LHgg.xml
+++ b/Models/Flightdeck/Instruments/torque/LHgg.xml
@@ -19,7 +19,7 @@ Syd Adams
     </animation>
  
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/torque/LHt5.xml
+++ b/Models/Flightdeck/Instruments/torque/LHt5.xml
@@ -16,12 +16,10 @@ Syd Adams
         <object-name>vitre</object-name>
     </animation>
   
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/torque/LHt5.xml
+++ b/Models/Flightdeck/Instruments/torque/LHt5.xml
@@ -17,7 +17,7 @@ Syd Adams
     </animation>
   
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/torque/LHtorque.xml
+++ b/Models/Flightdeck/Instruments/torque/LHtorque.xml
@@ -18,7 +18,7 @@ Syd Adams
     </animation>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/torque/LHtorque.xml
+++ b/Models/Flightdeck/Instruments/torque/LHtorque.xml
@@ -17,12 +17,10 @@ Syd Adams
         <object-name>vitre</object-name>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/torque/RHgg.xml
+++ b/Models/Flightdeck/Instruments/torque/RHgg.xml
@@ -18,12 +18,10 @@ Syd Adams
         <object-name>vitre</object-name> 
     </animation>
  
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/torque/RHgg.xml
+++ b/Models/Flightdeck/Instruments/torque/RHgg.xml
@@ -19,7 +19,7 @@ Syd Adams
     </animation>
  
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/torque/RHt5.xml
+++ b/Models/Flightdeck/Instruments/torque/RHt5.xml
@@ -16,12 +16,10 @@ Syd Adams
         <object-name>vitre</object-name>
     </animation>
   
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/torque/RHt5.xml
+++ b/Models/Flightdeck/Instruments/torque/RHt5.xml
@@ -17,7 +17,7 @@ Syd Adams
     </animation>
   
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/torque/RHtorque.xml
+++ b/Models/Flightdeck/Instruments/torque/RHtorque.xml
@@ -18,7 +18,7 @@ Syd Adams
     </animation>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/torque/RHtorque.xml
+++ b/Models/Flightdeck/Instruments/torque/RHtorque.xml
@@ -17,12 +17,10 @@ Syd Adams
         <object-name>vitre</object-name>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/torque/T5.ac
+++ b/Models/Flightdeck/Instruments/torque/T5.ac
@@ -1,5 +1,5 @@
 AC3Db
-MATERIAL "transparent.002" rgb 0.549 0.569 0.592  amb 0 0 0  emis 0.043 0.043 0.043  spec 1 1 1  shi 50  trans 0.804
+MATERIAL "glass.000" rgb 0.014 0.014 0.014 amb 0.5 0.5 0.5 emis 0 0 0 spec 0.844 0.844 0.844 shi 5 trans 0.850
 MATERIAL "WhitePaint.001" rgb 1 1 1  amb 1 1 1  emis 0.043 0.043 0.043  spec 0.502 0.502 0.502  shi 64  trans 0
 OBJECT world
 kids 5

--- a/Models/Flightdeck/Instruments/torque/gg-rpm.ac
+++ b/Models/Flightdeck/Instruments/torque/gg-rpm.ac
@@ -1,5 +1,5 @@
 AC3Db
-MATERIAL "transparent.002" rgb 0.549 0.569 0.592  amb 0 0 0  emis 0.043 0.043 0.043  spec 1 1 1  shi 50  trans 0.804
+MATERIAL "glass.000" rgb 0.014 0.014 0.014 amb 0.5 0.5 0.5 emis 0 0 0 spec 0.844 0.844 0.844 shi 5 trans 0.850
 MATERIAL "WhitePaint" rgb 1 1 1  amb 1 1 1  emis 0.043 0.043 0.043  spec 0.502 0.502 0.502  shi 64  trans 0
 OBJECT world
 kids 7

--- a/Models/Flightdeck/Instruments/torque/torque.ac
+++ b/Models/Flightdeck/Instruments/torque/torque.ac
@@ -1,5 +1,5 @@
 AC3Db
-MATERIAL "transparent.002" rgb 0.549 0.569 0.592  amb 0 0 0  emis 0.043 0.043 0.043  spec 1 1 1  shi 50  trans 0.804
+MATERIAL "glass.000" rgb 0.014 0.014 0.014 amb 0.5 0.5 0.5 emis 0 0 0 spec 0.844 0.844 0.844 shi 5 trans 0.850
 MATERIAL "WhitePaint" rgb 1 1 1  amb 1 1 1  emis 0.043 0.043 0.043  spec 0.502 0.502 0.502  shi 64  trans 0
 OBJECT world
 kids 6

--- a/Models/Flightdeck/Instruments/transponder/gtx320a.ac
+++ b/Models/Flightdeck/Instruments/transponder/gtx320a.ac
@@ -1,6 +1,6 @@
 AC3Db
 MATERIAL "DefaultWhite.001" rgb 1 1 1  amb 1 1 1  emis 0.043 0.043 0.043  spec 0.5 0.5 0.5  shi 64  trans 0
-MATERIAL "transparent" rgb 0.547091 0.565624 0.595981  amb 0 0 0  emis 0.043 0.043 0.043  spec 1 1 1  shi 64  trans 0.502
+MATERIAL "glass.000" rgb 0.014 0.014 0.014 amb 0.5 0.5 0.5 emis 0 0 0 spec 0.844 0.844 0.844 shi 5 trans 0.850
 OBJECT world
 kids 13
 OBJECT poly

--- a/Models/Flightdeck/Instruments/transponder/gtx320a.xml
+++ b/Models/Flightdeck/Instruments/transponder/gtx320a.xml
@@ -48,7 +48,7 @@
     </animation>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/transponder/gtx320a.xml
+++ b/Models/Flightdeck/Instruments/transponder/gtx320a.xml
@@ -47,12 +47,10 @@
         <max-m> 45 </max-m>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/Instruments/vsi/vsi.ac
+++ b/Models/Flightdeck/Instruments/vsi/vsi.ac
@@ -1,5 +1,5 @@
 AC3Db
-MATERIAL "transparent.001" rgb 0.549 0.569 0.592  amb 0 0 0  emis 0.043 0.043 0.043  spec 1 1 1  shi 50  trans 0.804
+MATERIAL "glass.000" rgb 0.014 0.014 0.014 amb 0.5 0.5 0.5 emis 0 0 0 spec 0.844 0.844 0.844 shi 5 trans 0.850
 MATERIAL "ai.003" rgb 1 1 1  amb 1 1 1  emis 0.043 0.043 0.043  spec 0.502 0.502 0.502  shi 64  trans 0
 OBJECT world
 kids 6

--- a/Models/Flightdeck/Instruments/vsi/vsi.xml
+++ b/Models/Flightdeck/Instruments/vsi/vsi.xml
@@ -23,7 +23,7 @@
     </animation>
 
     <effect>
-        <inherits-from>Effects/glass</inherits-from>
+        <inherits-from>Aircraft/dhc6/Models/Effects/interior/dhc6-interior-vitre-reflection</inherits-from>
         <object-name>vitre</object-name>
     </effect>
 

--- a/Models/Flightdeck/Instruments/vsi/vsi.xml
+++ b/Models/Flightdeck/Instruments/vsi/vsi.xml
@@ -22,12 +22,10 @@
         <object-name>vitre</object-name>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>vitre</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Flightdeck/flightdeck.xml
+++ b/Models/Flightdeck/flightdeck.xml
@@ -2857,7 +2857,7 @@ Also For IFR training and dual control in the Multiplayer space (pending).
             <repeatable>false</repeatable>
             <binding>
             <command>property-toggle</command>
-            <property>controls/gear/parkingbrake-lever</property>
+            <property>controls/gear/brake-parking</property>
         </binding>
         </action>
         <hovered>
@@ -2866,7 +2866,7 @@ Also For IFR training and dual control in the Multiplayer space (pending).
                 <tooltip-id>parkingbrake-lever</tooltip-id>
                 <label>Brake-parking: %s</label>
                 <mapping>on-off</mapping>
-            <property>controls/gear/parkingbrake-lever</property>
+            <property>controls/gear/brake-parking</property>
             </binding>
         </hovered>
     </animation>

--- a/Models/Flightdeck/flightdeck.xml
+++ b/Models/Flightdeck/flightdeck.xml
@@ -5083,14 +5083,12 @@ Also For IFR training and dual control in the Multiplayer space (pending).
         </axis>
     </animation>
 
-    <animation>
-        <type>shader</type>
-        <shader>chrome</shader>
-        <texture>Aircraft/Generic/Effects/glass_shader.png</texture>
+    <effect>
+        <inherits-from>Effects/glass</inherits-from>
         <object-name>glass-elevator</object-name>
         <object-name>glass-rudder</object-name>
         <object-name>glass-aileron</object-name>
-    </animation>
+    </effect>
 
     <animation>
         <type>noshadow</type>

--- a/Models/Lights/beacon-light.xml
+++ b/Models/Lights/beacon-light.xml
@@ -223,6 +223,19 @@
             <b>0.1</b>
             <a>1.0</a>
         </specular>
+        <color>
+            <r>0.8</r>
+            <g>0.2</g>
+            <b>0.1</b>
+        </color>
+        <intensity>
+            <expression>
+                <product>
+                    <value>45</value>
+                    <property>sim/multiplay/generic/float[8]</property>
+                </product>
+            </expression>
+        </intensity>
         <dim-factor>
             <property>sim/multiplay/generic/float[8]</property>
         </dim-factor>

--- a/Models/Lights/landing-light-left.xml
+++ b/Models/Lights/landing-light-left.xml
@@ -242,6 +242,19 @@
             <b>0.95</b>
             <a>0</a>
         </specular>
+        <color>
+            <r>1.00</r>
+            <g>0.95</g>
+            <b>0.95</b>
+        </color>
+        <intensity>
+            <expression>
+                <product>
+                    <value>50000</value>
+                    <property>sim/multiplay/generic/float[4]</property>
+                </product>
+            </expression>
+        </intensity>
         <dim-factor>
             <property>sim/multiplay/generic/float[4]</property>
         </dim-factor>
@@ -251,7 +264,7 @@
             <q>0.000001875</q>
         </attenuation>
         <spot-cutoff>30</spot-cutoff>
-        <spot-exponent>40</spot-exponent>
+        <spot-exponent>70</spot-exponent>
         <range-m>500</range-m>
     </light>
 

--- a/Models/Lights/landing-light-right.xml
+++ b/Models/Lights/landing-light-right.xml
@@ -242,6 +242,19 @@
             <b>0.95</b>
             <a>0</a>
         </specular>
+        <color>
+            <r>1.00</r>
+            <g>0.95</g>
+            <b>0.95</b>
+        </color>
+        <intensity>
+            <expression>
+                <product>
+                    <value>50000</value>
+                    <property>sim/multiplay/generic/float[5]</property>
+                </product>
+            </expression>
+        </intensity>
         <dim-factor>
             <property>sim/multiplay/generic/float[5]</property>
         </dim-factor>
@@ -251,7 +264,7 @@
             <q>0.000001875</q>
         </attenuation>
         <spot-cutoff>30</spot-cutoff>
-        <spot-exponent>40</spot-exponent>
+        <spot-exponent>70</spot-exponent>
         <range-m>500</range-m>
     </light>
 

--- a/Models/Lights/nav-light-left.xml
+++ b/Models/Lights/nav-light-left.xml
@@ -216,6 +216,19 @@
             <b>0.4</b>
             <a>0.0</a>
         </specular>
+        <color>
+            <r>1.0</r>
+            <g>0.4</g>
+            <b>0.4</b>
+        </color>
+        <intensity>
+            <expression>
+                <product>
+                    <value>100</value>
+                    <property>sim/multiplay/generic/float[3]</property>
+                </product>
+            </expression>
+        </intensity>
         <dim-factor>
             <property>sim/multiplay/generic/float[3]</property>
         </dim-factor>

--- a/Models/Lights/nav-light-right.xml
+++ b/Models/Lights/nav-light-right.xml
@@ -216,6 +216,19 @@
             <b>0.4</b>
             <a>0.0</a>
         </specular>
+        <color>
+            <r>0.4</r>
+            <g>1.0</g>
+            <b>0.4</b>
+        </color>
+        <intensity>
+            <expression>
+                <product>
+                    <value>100</value>
+                    <property>sim/multiplay/generic/float[3]</property>
+                </product>
+            </expression>
+        </intensity>
         <dim-factor>
             <property>sim/multiplay/generic/float[3]</property>
         </dim-factor>

--- a/Models/Lights/nav-light-tail.xml
+++ b/Models/Lights/nav-light-tail.xml
@@ -216,6 +216,19 @@
             <b>1.0</b>
             <a>0.0</a>
         </specular>
+        <color>
+            <r>1.0</r>
+            <g>1.0</g>
+            <b>1.0</b>
+        </color>
+        <intensity>
+            <expression>
+                <product>
+                    <value>100</value>
+                    <property>sim/multiplay/generic/float[3]</property>
+                </product>
+            </expression>
+        </intensity>
         <dim-factor>
             <property>sim/multiplay/generic/float[3]</property>
         </dim-factor>

--- a/Models/Lights/strobe-light-left.xml
+++ b/Models/Lights/strobe-light-left.xml
@@ -216,6 +216,19 @@
             <b>1.0</b>
             <a>0.0</a>
         </specular>
+        <color>
+            <r>1.0</r>
+            <g>1.0</g>
+            <b>1.0</b>
+        </color>
+        <intensity>
+            <expression>
+                <product>
+                    <value>100</value>
+                    <property>sim/multiplay/generic/float[7]</property>
+                </product>
+            </expression>
+        </intensity>
         <dim-factor>
             <property>sim/multiplay/generic/float[7]</property>
         </dim-factor>

--- a/Models/Lights/strobe-light-right.xml
+++ b/Models/Lights/strobe-light-right.xml
@@ -216,6 +216,19 @@
             <b>1.0</b>
             <a>0.0</a>
         </specular>
+        <color>
+            <r>1.0</r>
+            <g>1.0</g>
+            <b>1.0</b>
+        </color>
+        <intensity>
+            <expression>
+                <product>
+                    <value>100</value>
+                    <property>sim/multiplay/generic/float[7]</property>
+                </product>
+            </expression>
+        </intensity>
         <dim-factor>
             <property>sim/multiplay/generic/float[7]</property>
         </dim-factor>

--- a/Models/Lights/taxi-light.xml
+++ b/Models/Lights/taxi-light.xml
@@ -242,6 +242,19 @@
             <b>0.95</b>
             <a>0</a>
         </specular>
+        <color>
+            <r>1.00</r>
+            <g>0.95</g>
+            <b>0.95</b>
+        </color>
+        <intensity>
+            <expression>
+                <product>
+                    <value>10000</value>
+                    <property>sim/multiplay/generic/float[6]</property>
+                </product>
+            </expression>
+        </intensity>
         <dim-factor>
             <property>sim/multiplay/generic/float[6]</property>
         </dim-factor>
@@ -251,7 +264,7 @@
             <q>0.0002</q>
         </attenuation>
         <spot-cutoff>89</spot-cutoff>
-        <spot-exponent>10</spot-exponent>
+        <spot-exponent>20</spot-exponent>
         <range-m>300</range-m>
     </light>
 

--- a/Models/dhc-6.ac
+++ b/Models/dhc-6.ac
@@ -16800,6 +16800,7 @@ refs 4
 kids 0
 OBJECT poly
 name "RHdoor.glass_interior"
+texture "glass-trans-texture-dummy.png"
 crease 45.000000
 numvert 8
 -3.61642 0.35381 -0.813848
@@ -16866,6 +16867,7 @@ refs 4
 kids 0
 OBJECT poly
 name "Lprop.disk"
+texture "transparent.png"
 crease 45.000000
 numvert 18
 -2.60891 1.01225 2.857
@@ -17082,6 +17084,7 @@ refs 3
 kids 0
 OBJECT poly
 name "LHLNDlight"
+texture "transparent.png"
 crease 45.000000
 numvert 4
 -1.01732 1.72806 3.14362
@@ -17099,6 +17102,7 @@ refs 4
 kids 0
 OBJECT poly
 name "LHdoor.glass_interior"
+texture "glass-trans-texture-dummy.png"
 crease 45.000000
 numvert 8
 -3.61642 0.353811 0.818928
@@ -17132,6 +17136,7 @@ refs 4
 kids 0
 OBJECT poly
 name "glass_interior"
+texture "glass-trans-texture-dummy.png"
 crease 45.000000
 numvert 16
 -3.99801 0.544064 -0.501308
@@ -17637,6 +17642,7 @@ refs 4
 kids 0
 OBJECT poly
 name "Rprop.disk"
+texture "transparent.png"
 crease 45.000000
 numvert 18
 -2.66047 1.91612 -3.76087
@@ -17853,6 +17859,7 @@ refs 3
 kids 0
 OBJECT poly
 name "RHLNDlight"
+texture "transparent.png"
 crease 45.000000
 numvert 4
 -1.01732 1.72806 -4.34362
@@ -17870,6 +17877,7 @@ refs 4
 kids 0
 OBJECT poly
 name "RRdoor.glass_interior"
+texture "glass-trans-texture-dummy.png"
 crease 45.000000
 numvert 8
 2.11112 0.325395 -0.798688
@@ -17940,6 +17948,7 @@ refs 4
 kids 0
 OBJECT poly
 name "Lrdoor.glass_interior"
+texture "glass-trans-texture-dummy.png"
 crease 45.000000
 numvert 8
 2.15593 0.541519 0.794125
@@ -18010,6 +18019,7 @@ refs 4
 kids 0
 OBJECT poly
 name "cabin-glass_interior"
+texture "glass-trans-texture-dummy.png"
 crease 45.000000
 numvert 104
 -1.0151 0.262212 -0.891063
@@ -44120,6 +44130,7 @@ refs 3
 kids 0
 OBJECT poly
 name "strobe.1"
+texture "transparent.png"
 crease 45.000000
 numvert 4
 -0.6 0.6 0
@@ -44137,6 +44148,7 @@ refs 4
 kids 0
 OBJECT poly
 name "strobe.2"
+texture "transparent.png"
 crease 45.000000
 numvert 4
 -0.6 0.6 0

--- a/Nasal/interpolate.nas
+++ b/Nasal/interpolate.nas
@@ -344,7 +344,7 @@ setlistener("/controls/switches/firebell-switch", func(v) {
     }
 });
 
-setlistener("/controls/gear/parkingbrake-lever", func(v) {
+setlistener("/controls/gear/brake-parking", func(v) {
     if(v.getValue()){
         interpolate("/controls/gear/parkingbrake-lever-pos", 1, 0.1);
     }else{

--- a/Nasal/systems.nas
+++ b/Nasal/systems.nas
@@ -173,7 +173,7 @@ var Startup_yasim = func{
             setprop("controls/flight/flaps",0.25);
 
 # SurferTim changed
-            setprop("controls/gear/parkingbrake-lever",1);
+            setprop("controls/gear/brake-parking",1);
             setprop("instrumentation/garmin196/light",0.2);
 #           setprop("instrumentation/adf/ident-audible",1);  (now controlled by KMA20 audio panel, see KMA20_AudioPanel.nas)
             setprop("controls/flight/elevator-trim",-0.2);
@@ -257,7 +257,7 @@ var Startup_jsb = func{
     setprop("controls/lighting/strobe",1);
     setprop("controls/flight/flaplever",0.25);
     setprop("controls/flight/flaps",0.25);
-    setprop("controls/gear/parkingbrake-lever",0);
+    setprop("controls/gear/brake-parking",0);
     setprop("controls/flight/elevator-trim",-0.2);
     setprop("controls/flight/rudder-trim",0.12);
     setprop("controls/engines/engine[0]/condition",1);
@@ -309,7 +309,7 @@ var Shutdown = func{
     setprop("controls/lighting/landing-light[1]",0);
     setprop("controls/flight/flaplever",0);
     setprop("controls/flight/flaps",0);
-    setprop("controls/gear/parkingbrake-lever",1);
+    setprop("controls/gear/brake-parking",1);
     setprop("controls/engines/engine[0]/intake-deflector",0.0);
     setprop("controls/engines/engine[1]/intake-deflector",0.0);
     setprop("controls/lighting/flight-comp",0);
@@ -841,7 +841,7 @@ var close_reverse_info = func {
 #        return;
 #    }
 #
-#    var p = "/controls/gear/parkingbrake-lever";
+#    var p = "/controls/gear/brake-parking";
 #    setprop(p, var i = !getprop(p));
 #    return i;
 #};

--- a/Sounds/dhc6-sound.xml
+++ b/Sounds/dhc6-sound.xml
@@ -811,7 +811,7 @@
             <path>Aircraft/dhc6/Sounds/dhc6-brake-lever.wav</path>
             <condition>
                 <not>
-                    <property>controls/gear/parkingbrake-lever</property>
+                    <property>controls/gear/brake-parking</property>
                 </not>
             </condition>
             <volume>
@@ -835,7 +835,7 @@
             <path>Aircraft/dhc6/Sounds/dhc6-brake-lever.wav</path>
             <condition>
                 <and>
-                    <property>controls/gear/parkingbrake-lever</property>
+                    <property>controls/gear/brake-parking</property>
                     <value>0</value>
                 </and>
             </condition>

--- a/Systems/equipment.xml
+++ b/Systems/equipment.xml
@@ -159,7 +159,7 @@
         <input>
             <or>
                 <!-- The actual parking brake controlled by the pilot -->
-                <property>/controls/gear/parkingbrake-lever</property>
+                <property>/controls/gear/brake-parking</property>
 
                 <property>/sim/model/equipment/left-tiedown-wheels</property>
                 <property>/sim/model/equipment/right-tiedown-wheels</property>
@@ -174,7 +174,7 @@
             </or>
         </input>
         <output>
-            <property>/controls/gear/brake-parking</property>
+            <property>/controls/gear/brake-parking-out</property>
         </output>
     </logic>
 

--- a/Systems/flightrecorder.xml
+++ b/Systems/flightrecorder.xml
@@ -280,11 +280,6 @@
         </signal>
         <signal>
             <type>float</type>
-            <property type="string">/controls/gear/parkingbrake-lever</property>
-            <interpolation>linear</interpolation>
-        </signal>
-        <signal>
-            <type>float</type>
             <property type="string">/controls/lighting/beacon</property>
             <interpolation>linear</interpolation>
         </signal>

--- a/Tutorials/Before engines start.xml
+++ b/Tutorials/Before engines start.xml
@@ -55,7 +55,7 @@
             <message>Set the parking brake</message>
             <condition>
                 <equals>
-                    <property>/controls/gear/parkingbrake-lever</property>
+                    <property>/controls/gear/brake-parking</property>
                     <value>0</value>
                 </equals>
             </condition>
@@ -63,7 +63,7 @@
         <exit>
             <condition>
                 <equals>
-                    <property>/controls/gear/parkingbrake-lever</property>
+                    <property>/controls/gear/brake-parking</property>
                     <value>1</value>
                 </equals>
             </condition>

--- a/Tutorials/Securing aircraft.xml
+++ b/Tutorials/Securing aircraft.xml
@@ -33,7 +33,7 @@
             <message>Set the parking brake</message>
             <condition>
                 <equals>
-                    <property>/controls/gear/parkingbrake-lever</property>
+                    <property>/controls/gear/brake-parking</property>
                     <value>0</value>
                 </equals>
             </condition>
@@ -41,7 +41,7 @@
         <exit>
             <condition>
                 <equals>
-                    <property>/controls/gear/parkingbrake-lever</property>
+                    <property>/controls/gear/brake-parking</property>
                     <value>1</value>
                 </equals>
             </condition>

--- a/Tutorials/Starting the engines.xml
+++ b/Tutorials/Starting the engines.xml
@@ -12,7 +12,7 @@
             <value>0</value>
         </set>
         <set>
-            <property>/controls/gear/parkingbrake-lever</property>
+            <property>/controls/gear/brake-parking</property>
             <value>1</value>
         </set>
         <set>

--- a/Tutorials/dhc6-checklists.xml
+++ b/Tutorials/dhc6-checklists.xml
@@ -216,7 +216,7 @@
                 </marker>
                 <condition>
                     <equals>
-                        <property>/controls/gear/parkingbrake-lever</property>
+                        <property>/controls/gear/brake-parking</property>
                         <value>1</value>
                     </equals>
                 </condition>
@@ -2289,7 +2289,7 @@
             </marker>
             <condition>
                 <equals>
-                    <property>/controls/gear/parkingbrake-lever</property>
+                    <property>/controls/gear/brake-parking</property>
                     <value>0</value>
                 </equals>
             </condition>
@@ -2367,7 +2367,7 @@
                 </marker>
                 <condition>
                     <equals>
-                        <property>/controls/gear/parkingbrake-lever</property>
+                        <property>/controls/gear/brake-parking</property>
                         <value>1</value>
                     </equals>
                 </condition>
@@ -2552,7 +2552,7 @@
             </marker>
             <condition>
                 <equals>
-                    <property>/controls/gear/parkingbrake-lever</property>
+                    <property>/controls/gear/brake-parking</property>
                     <value>0</value>
                 </equals>
             </condition>
@@ -3261,7 +3261,7 @@
             </marker>
             <condition>
                 <equals>
-                    <property>/controls/gear/parkingbrake-lever</property>
+                    <property>/controls/gear/brake-parking</property>
                     <value>0</value>
                 </equals>
             </condition>
@@ -3515,7 +3515,7 @@
                 </marker>
                 <condition>
                     <equals>
-                        <property>/controls/gear/parkingbrake-lever</property>
+                        <property>/controls/gear/brake-parking</property>
                         <value>1</value>
                     </equals>
                 </condition>

--- a/dhc6-base.xml
+++ b/dhc6-base.xml
@@ -273,6 +273,7 @@
             <tag>2-engine</tag>
         </tags>
 
+        <minimum-fg-version>2020.4.0</minimum-fg-version>
     </sim>
 
     <autopilot>

--- a/dhc6-base.xml
+++ b/dhc6-base.xml
@@ -273,7 +273,7 @@
             <tag>2-engine</tag>
         </tags>
 
-        <minimum-fg-version>2020.4.0</minimum-fg-version>
+        <minimum-fg-version>2020.3.0</minimum-fg-version>
     </sim>
 
     <autopilot>

--- a/dhc6-set.xml
+++ b/dhc6-set.xml
@@ -153,7 +153,7 @@
 
     <controls>
         <gear>
-            <brake-parking>1</brake-parking>
+            <brake-parking-out>1</brake-parking-out>
         </gear>
     </controls>
 

--- a/dhc6.xml
+++ b/dhc6.xml
@@ -145,13 +145,13 @@
     <gear x="-1" y="2.65" z="-1.83" compression=".3"
         spring="1.0" damp="0.6" sfric="1.4" dfric="1.2">
         <control-input axis="/controls/gear/brake-left" control="BRAKE"/>
-        <control-input axis="/controls/gear/brake-parking" control="BRAKE"/>
+        <control-input axis="/controls/gear/brake-parking-out" control="BRAKE"/>
     </gear>
 
     <gear x="-1" y="-2.65" z="-1.83" compression=".3"
         spring="1.0" damp="0.6" sfric="1.4" dfric="1.2">
         <control-input axis="/controls/gear/brake-right" control="BRAKE"/>
-        <control-input axis="/controls/gear/brake-parking" control="BRAKE"/>
+        <control-input axis="/controls/gear/brake-parking-out" control="BRAKE"/>
     </gear>
 
     <!--

--- a/dhc6F-set.xml
+++ b/dhc6F-set.xml
@@ -154,7 +154,7 @@
 
     <controls>
         <gear>
-            <brake-parking>1</brake-parking>
+            <brake-parking-out>1</brake-parking-out>
             <water-rudder-pos type="double">0</water-rudder-pos>
             <water-rudder-down type="bool">0</water-rudder-down>
         </gear>

--- a/dhc6F.xml
+++ b/dhc6F.xml
@@ -174,7 +174,7 @@
     </gear>
 
     <gear x="-1.26" y="1.75" z="-2.68" compression="0.4" spring = "3.5" sfric = "0.5" dfric=".45" retract-time="4" initial-load="1" damp="10.1">
-        <control-input control="BRAKE" axis="/controls/gear/brake-parking" />
+        <control-input control="BRAKE" axis="/controls/gear/brake-parking-out" />
         <control-input control="BRAKE" axis="/controls/gear/brake-left" />
         <control-input axis="/controls/gear/gear-down" control="EXTEND"/>
         <control-output control="EXTEND" prop="/gear/gear[6]/position-norm"/>
@@ -182,7 +182,7 @@
     </gear>
 
     <gear x="-1.26" y="-1.75" z="-2.68" compression="0.4" spring = "3.5" sfric = "0.5" dfric=".45" retract-time="4" initial-load="1" damp="10.1">
-        <control-input control="BRAKE" axis="/controls/gear/brake-parking" />
+        <control-input control="BRAKE" axis="/controls/gear/brake-parking-out" />
         <control-input control="BRAKE" axis="/controls/gear/brake-right" />
         <control-input axis="/controls/gear/gear-down" control="EXTEND"/>
         <control-output control="EXTEND" prop="/gear/gear[7]/position-norm"/>

--- a/dhc6S-set.xml
+++ b/dhc6S-set.xml
@@ -158,7 +158,7 @@
 
     <controls>
         <gear>
-            <brake-parking>1</brake-parking>
+            <brake-parking-out>1</brake-parking-out>
         </gear>
     </controls>
 

--- a/dhc6S.xml
+++ b/dhc6S.xml
@@ -146,13 +146,13 @@
     <gear x="-0.25" y="2.65" z="-1.8" compression=".3"
     spring="1.0" damp="0.6" sfric="0.3" dfric="0.2">
         <control-input axis="/controls/gear/brake-left" control="BRAKE"/>
-        <control-input axis="/controls/gear/brake-parking" control="BRAKE"/>
+        <control-input axis="/controls/gear/brake-parking-out" control="BRAKE"/>
     </gear>
 
     <gear x="-0.25" y="-2.65" z="-1.8" compression=".3"
     spring="1.0" damp="0.6" sfric="0.3" dfric="0.2">
         <control-input axis="/controls/gear/brake-right" control="BRAKE"/>
-        <control-input axis="/controls/gear/brake-parking" control="BRAKE"/>
+        <control-input axis="/controls/gear/brake-parking-out" control="BRAKE"/>
     </gear>
 
     <!--

--- a/dhc6p-set.xml
+++ b/dhc6p-set.xml
@@ -154,7 +154,7 @@
 
     <controls>
         <gear>
-            <brake-parking>1</brake-parking>
+            <brake-parking-out>1</brake-parking-out>
         </gear>
     </controls>
 

--- a/dhc6p.xml
+++ b/dhc6p.xml
@@ -145,13 +145,13 @@
     <gear x="-1" y="2.65" z="-1.83" compression=".3"
         spring="1.0" damp="0.6" sfric="1.4" dfric="1.2">
         <control-input axis="/controls/gear/brake-left" control="BRAKE"/>
-        <control-input axis="/controls/gear/brake-parking" control="BRAKE"/>
+        <control-input axis="/controls/gear/brake-parking-out" control="BRAKE"/>
     </gear>
 
     <gear x="-1" y="-2.65" z="-1.83" compression=".3"
         spring="1.0" damp="0.6" sfric="1.4" dfric="1.2">
         <control-input axis="/controls/gear/brake-right" control="BRAKE"/>
-        <control-input axis="/controls/gear/brake-parking" control="BRAKE"/>
+        <control-input axis="/controls/gear/brake-parking-out" control="BRAKE"/>
     </gear>
 
     <!--

--- a/dhc6pF-set.xml
+++ b/dhc6pF-set.xml
@@ -154,7 +154,7 @@
 
     <controls>
         <gear>
-            <brake-parking>1</brake-parking>
+            <brake-parking-out>1</brake-parking-out>
             <water-rudder-pos type="double">0</water-rudder-pos>
             <water-rudder-down type="bool">0</water-rudder-down>
         </gear>

--- a/dhc6pF.xml
+++ b/dhc6pF.xml
@@ -174,7 +174,7 @@
     </gear>
 
     <gear x="-1.26" y="1.75" z="-2.68" compression="0.4" spring = "3.5" sfric = "0.5" dfric=".45" retract-time="4" initial-load="1" damp="10.1">
-        <control-input control="BRAKE" axis="/controls/gear/brake-parking" />
+        <control-input control="BRAKE" axis="/controls/gear/brake-parking-out" />
         <control-input control="BRAKE" axis="/controls/gear/brake-left" />
         <control-input axis="/controls/gear/gear-down" control="EXTEND"/>
         <control-output control="EXTEND" prop="/gear/gear[6]/position-norm"/>
@@ -182,7 +182,7 @@
     </gear>
 
     <gear x="-1.26" y="-1.75" z="-2.68" compression="0.4" spring = "3.5" sfric = "0.5" dfric=".45" retract-time="4" initial-load="1" damp="10.1">
-        <control-input control="BRAKE" axis="/controls/gear/brake-parking" />
+        <control-input control="BRAKE" axis="/controls/gear/brake-parking-out" />
         <control-input control="BRAKE" axis="/controls/gear/brake-right" />
         <control-input axis="/controls/gear/gear-down" control="EXTEND"/>
         <control-output control="EXTEND" prop="/gear/gear[7]/position-norm"/>

--- a/dhc6pS-set.xml
+++ b/dhc6pS-set.xml
@@ -158,7 +158,7 @@
 
     <controls>
         <gear>
-            <brake-parking>1</brake-parking>
+            <brake-parking-out>1</brake-parking-out>
         </gear>
     </controls>
 

--- a/dhc6pS.xml
+++ b/dhc6pS.xml
@@ -146,13 +146,13 @@
     <gear x="-0.25" y="2.65" z="-1.8" compression=".3"
     spring="1.0" damp="0.6" sfric="0.3" dfric="0.2">
         <control-input axis="/controls/gear/brake-left" control="BRAKE"/>
-        <control-input axis="/controls/gear/brake-parking" control="BRAKE"/>
+        <control-input axis="/controls/gear/brake-parking-out" control="BRAKE"/>
     </gear>
 
     <gear x="-0.25" y="-2.65" z="-1.8" compression=".3"
     spring="1.0" damp="0.6" sfric="0.3" dfric="0.2">
         <control-input axis="/controls/gear/brake-right" control="BRAKE"/>
-        <control-input axis="/controls/gear/brake-parking" control="BRAKE"/>
+        <control-input axis="/controls/gear/brake-parking-out" control="BRAKE"/>
     </gear>
 
     <!--


### PR DESCRIPTION
This PR changes the following:
- minimum FG version now specified
- usage of effects framework instead of deprecated shader animation
- the default property for the parking brake is now used, this fixes joystick bindings
- change the glass materials to be more transparent -> HDR compat
- use a better interior glass effect -> HDR compat
- re-add the prop textures for the spinning prop disc that were removed (by accident?)
- add lights that are compatible with HDR